### PR TITLE
feat: mostrar fechas y horas disponibles

### DIFF
--- a/src/main/java/agile/aresback/api/DisponibilidadController.java
+++ b/src/main/java/agile/aresback/api/DisponibilidadController.java
@@ -1,0 +1,30 @@
+package agile.aresback.api;
+
+import agile.aresback.dto.DisponibilidadDto;
+import agile.aresback.service.DisponibilidadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/disponibilidad")
+@RequiredArgsConstructor
+public class DisponibilidadController {
+
+    private final DisponibilidadService disponibilidadService;
+
+    @GetMapping
+    public ResponseEntity<List<DisponibilidadDto>> obtenerDisponibles(
+            @RequestParam("fecha") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fecha,
+            @RequestParam("horaInicio") @DateTimeFormat(iso = DateTimeFormat.ISO.TIME) LocalTime horaInicio,
+            @RequestParam("horaFin") @DateTimeFormat(iso = DateTimeFormat.ISO.TIME) LocalTime horaFin
+    ) {
+        List<DisponibilidadDto> disponibles = disponibilidadService.obtenerMesasDisponibles(fecha, horaInicio, horaFin);
+        return ResponseEntity.ok(disponibles);
+    }
+}

--- a/src/main/java/agile/aresback/api/DisponibilidadController.java
+++ b/src/main/java/agile/aresback/api/DisponibilidadController.java
@@ -1,30 +1,25 @@
 package agile.aresback.api;
 
 import agile.aresback.dto.DisponibilidadDto;
+import agile.aresback.dto.MesaDto;
+import agile.aresback.model.entity.Mesa;
 import agile.aresback.service.DisponibilidadService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/disponibilidad")
-@RequiredArgsConstructor
 public class DisponibilidadController {
 
-    private final DisponibilidadService disponibilidadService;
+    @Autowired
+    private DisponibilidadService disponibilidadService;
 
-    @GetMapping
-    public ResponseEntity<List<DisponibilidadDto>> obtenerDisponibles(
-            @RequestParam("fecha") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fecha,
-            @RequestParam("horaInicio") @DateTimeFormat(iso = DateTimeFormat.ISO.TIME) LocalTime horaInicio,
-            @RequestParam("horaFin") @DateTimeFormat(iso = DateTimeFormat.ISO.TIME) LocalTime horaFin
-    ) {
-        List<DisponibilidadDto> disponibles = disponibilidadService.obtenerMesasDisponibles(fecha, horaInicio, horaFin);
+    @PostMapping
+    public ResponseEntity<List<MesaDto>> consultarDisponibilidad(@RequestBody DisponibilidadDto dto) {
+        List<MesaDto> disponibles = disponibilidadService.buscarMesasDisponibles(dto.getFecha(), dto.getHora());
         return ResponseEntity.ok(disponibles);
     }
 }

--- a/src/main/java/agile/aresback/api/ReservationController.java
+++ b/src/main/java/agile/aresback/api/ReservationController.java
@@ -16,12 +16,12 @@ public class ReservationController {
     private ReservationService reservationService;
 
     // Endpoint para obtener las reservas de una mesa
-    @GetMapping("/mesa/{mesaId}")
+   /* @GetMapping("/mesa/{mesaId}")
     public List<Reservation> getReservationsForMesa(@PathVariable Integer mesaId) {
         Mesa mesa = new Mesa();  // Aquí puedes cargar la mesa por ID desde la base de datos si es necesario
         mesa.setId(mesaId);
         return reservationService.getReservationsForMesa(mesa);
-    }
+    }*/
 
     // Endpoint para crear una nueva reserva
     @PostMapping("/create")

--- a/src/main/java/agile/aresback/dto/DisponibilidadDto.java
+++ b/src/main/java/agile/aresback/dto/DisponibilidadDto.java
@@ -1,15 +1,14 @@
 package agile.aresback.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Setter
 public class DisponibilidadDto {
-    private Integer numeroMesa;
-    private Integer capacidad;
-    private String zona;
-    private String estado;
+    private LocalDate fecha;
+    private LocalTime hora;
 }

--- a/src/main/java/agile/aresback/dto/DisponibilidadDto.java
+++ b/src/main/java/agile/aresback/dto/DisponibilidadDto.java
@@ -1,0 +1,15 @@
+package agile.aresback.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DisponibilidadDto {
+    private Integer numeroMesa;
+    private Integer capacidad;
+    private String zona;
+    private String estado;
+}

--- a/src/main/java/agile/aresback/mapper/ReservationMapper.java
+++ b/src/main/java/agile/aresback/mapper/ReservationMapper.java
@@ -17,20 +17,16 @@ public class ReservationMapper {
         ReservationDTO dto = new ReservationDTO();
         dto.setId(reservation.getId());
 
-        // Fecha registro: LocalDateTime -> LocalDate (solo fecha)
-        if (reservation.getFechaRegistro() != null) {
-            dto.setFechaRegistro(reservation.getFechaRegistro().toLocalDate());
-        }
+        // ✅ Ya es LocalDate directamente
+        dto.setFechaRegistro(reservation.getFechaRegistro());
 
-        // Fecha reservada: LocalDate (igual que DTO)
         dto.setFechaReservada(reservation.getFechaReservada());
-
-        // Hora inicio y fin (LocalTime igual en DTO)
         dto.setHoraInicio(reservation.getHoraInicio());
         dto.setHoraFin(reservation.getHoraFin());
 
-        // Estado reserva a string
-        dto.setStateReservation(reservation.getStateReservation() != null ? reservation.getStateReservation().name() : null);
+        dto.setStateReservation(reservation.getStateReservation() != null
+                ? reservation.getStateReservation().name()
+                : null);
 
         dto.setMesaId(reservation.getMesa() != null ? reservation.getMesa().getId() : null);
 
@@ -58,17 +54,13 @@ public class ReservationMapper {
         Reservation reservation = new Reservation();
         reservation.setId(dto.getId());
 
-        // fechaRegistro debe asignarse en el servicio (no desde DTO)
+        // Se asigna en el servicio
         reservation.setFechaRegistro(null);
 
-        // fechaReservada: LocalDate es igual en DTO y entidad
         reservation.setFechaReservada(dto.getFechaReservada());
-
-        // Hora inicio y fin
         reservation.setHoraInicio(dto.getHoraInicio());
-        reservation.setHoraFin(dto.getHoraFin()); // o puede asignarse en servicio
+        reservation.setHoraFin(dto.getHoraFin());
 
-        // Estado reserva
         if (dto.getStateReservation() != null) {
             reservation.setStateReservation(StateReservation.valueOf(dto.getStateReservation()));
         } else {

--- a/src/main/java/agile/aresback/model/entity/Mesa.java
+++ b/src/main/java/agile/aresback/model/entity/Mesa.java
@@ -1,19 +1,33 @@
-@Id
-@GeneratedValue(strategy = GenerationType.IDENTITY)
-private Integer id;
+package agile.aresback.model.entity;
 
-@Column(name = "capacidad", nullable = false)
-private Integer capacidad;
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.List;
+import agile.aresback.model.enums.StateTable;
 
-@Column(name = "numero_mesa", nullable = false)
-private Integer numeroMesa;
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "mesa")
+public class Mesa {
 
-@Enumerated(EnumType.STRING)
-private StateTable estado;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
 
-@ManyToOne
-@JoinColumn(name = "zone_id")
-private Zone zone;
+    private Integer capacidad;
 
-@OneToMany(mappedBy = "mesa", cascade = CascadeType.ALL)
-private List<Reservation> reservations;
+    @Enumerated(EnumType.STRING)
+    private StateTable estado;
+
+    @Column(name = "numero_mesa", nullable = false)
+    private Integer numeroMesa;
+
+    @ManyToOne
+    @JoinColumn(name = "zone_id")
+    private Zone zone;
+
+    @OneToMany(mappedBy = "mesa")
+    private List<Reservation> reservations;
+}

--- a/src/main/java/agile/aresback/model/entity/Mesa.java
+++ b/src/main/java/agile/aresback/model/entity/Mesa.java
@@ -27,5 +27,4 @@ public class Mesa {
 
     @OneToMany(mappedBy = "mesa", cascade = CascadeType.ALL)
     private List<Reservation> reservation;
-
 }

--- a/src/main/java/agile/aresback/model/entity/Reservation.java
+++ b/src/main/java/agile/aresback/model/entity/Reservation.java
@@ -1,9 +1,12 @@
 package agile.aresback.model.entity;
+
 import agile.aresback.model.enums.StateReservation;
 import jakarta.persistence.*;
 import lombok.Data;
-import java.time.LocalDateTime;
+
+import java.time.LocalDate;
 import java.time.LocalTime;
+
 @Data
 @Entity
 @Table(name = "Reservation")
@@ -14,10 +17,10 @@ public class Reservation {
     private Integer id;
 
     @Column(name = "fecha_reservada", nullable = false)
-    private LocalDateTime fechaReservada;
+    private LocalDate fechaReservada;
 
     @Column(name = "fecha_registro", nullable = false)
-    private LocalDateTime fechaRegistro;
+    private LocalDate fechaRegistro;
 
     @Column(name = "hora_inicio", nullable = false)
     private LocalTime horaInicio;
@@ -28,7 +31,6 @@ public class Reservation {
     @Enumerated(EnumType.STRING)
     private StateReservation stateReservation;
 
-    // Relations
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mesa_id", nullable = false)
     private Mesa mesa;
@@ -41,4 +43,3 @@ public class Reservation {
     @JoinColumn(name = "client_id",nullable = false)
     private Client client;
 }
-

--- a/src/main/java/agile/aresback/model/entity/Reservation.java
+++ b/src/main/java/agile/aresback/model/entity/Reservation.java
@@ -28,7 +28,7 @@ public class Reservation {
     @Enumerated(EnumType.STRING)
     private StateReservation stateReservation;
 
-    // Relaciones
+    // Relations
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mesa_id", nullable = false)
     private Mesa mesa;

--- a/src/main/java/agile/aresback/model/enums/StateReservation.java
+++ b/src/main/java/agile/aresback/model/enums/StateReservation.java
@@ -4,6 +4,8 @@ public enum StateReservation {
 
     NO_ASISTIO,
     EN_ESPERA,
-    ASISTIO
+    ASISTIO,
+    EN_PROGRESO,
+    OCUPADA
 
 }

--- a/src/main/java/agile/aresback/repository/MesaRepository.java
+++ b/src/main/java/agile/aresback/repository/MesaRepository.java
@@ -1,10 +1,25 @@
 package agile.aresback.repository;
+
 import agile.aresback.model.entity.Mesa;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
 @Repository
 public interface MesaRepository extends JpaRepository<Mesa, Integer> {
-}
+    @Query(
+            "SELECT m FROM Mesa m WHERE m.id NOT IN (" +
+            "SELECT r.mesa.id FROM Reservation r " +
+            "WHERE r.fechaReservada = :fecha " +
+            "AND :horaInicio < r.horaFin AND :horaFin > r.horaInicio)")
+    List<Mesa> findAvailableMesas(@Param("fecha") LocalDateTime fecha,
+                                  @Param("horaInicio") LocalTime horaInicio,
+                                  @Param("horaFin") LocalTime horaFin);
 
+
+}

--- a/src/main/java/agile/aresback/repository/ReservationRepository.java
+++ b/src/main/java/agile/aresback/repository/ReservationRepository.java
@@ -4,6 +4,7 @@ import agile.aresback.model.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import agile.aresback.model.entity.Mesa;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/src/main/java/agile/aresback/repository/ReservationRepository.java
+++ b/src/main/java/agile/aresback/repository/ReservationRepository.java
@@ -3,12 +3,21 @@ package agile.aresback.repository;
 import agile.aresback.model.entity.Mesa;
 import agile.aresback.model.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Integer> {
 
     List<Reservation> findByMesa(Mesa mesa); // Obtener reservas de una mesa
     List<Reservation> findByFechaReservadaBetween(LocalDateTime startTime, LocalDateTime endTime); // Obtener reservas en un rango de tiempo
+    @Query("SELECT r FROM Reservation r WHERE r.fechaReservada = :fecha " +
+            "AND :horaInicio < r.horaFin AND :horaFin > r.horaInicio")
+    List<Reservation> findByFechaHora(@Param("fecha") LocalDateTime fecha,
+                                      @Param("horaInicio") LocalTime horaInicio,
+                                      @Param("horaFin") LocalTime horaFin);
+
 }

--- a/src/main/java/agile/aresback/repository/ReservationRepository.java
+++ b/src/main/java/agile/aresback/repository/ReservationRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+public interface ReservationRepository extends JpaRepository<Reservation, Integer> {
     List<Reservation> findByFechaReservadaBetween(LocalDateTime inicio, LocalDateTime fin);
 }

--- a/src/main/java/agile/aresback/repository/ReservationRepository.java
+++ b/src/main/java/agile/aresback/repository/ReservationRepository.java
@@ -1,23 +1,11 @@
 package agile.aresback.repository;
 
-import agile.aresback.model.entity.Mesa;
 import agile.aresback.model.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
-public interface ReservationRepository extends JpaRepository<Reservation, Integer> {
-
-    List<Reservation> findByMesa(Mesa mesa); // Obtener reservas de una mesa
-    List<Reservation> findByFechaReservadaBetween(LocalDateTime startTime, LocalDateTime endTime); // Obtener reservas en un rango de tiempo
-    @Query("SELECT r FROM Reservation r WHERE r.fechaReservada = :fecha " +
-            "AND :horaInicio < r.horaFin AND :horaFin > r.horaInicio")
-    List<Reservation> findByFechaHora(@Param("fecha") LocalDateTime fecha,
-                                      @Param("horaInicio") LocalTime horaInicio,
-                                      @Param("horaFin") LocalTime horaFin);
-
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    List<Reservation> findByFechaReservadaBetween(LocalDateTime inicio, LocalDateTime fin);
 }

--- a/src/main/java/agile/aresback/service/DisponibilidadService.java
+++ b/src/main/java/agile/aresback/service/DisponibilidadService.java
@@ -1,10 +1,11 @@
 package agile.aresback.service;
 
-import agile.aresback.dto.DisponibilidadDto;
+import agile.aresback.dto.MesaDto;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
 public interface DisponibilidadService {
-    List<DisponibilidadDto> obtenerMesasDisponibles(LocalDate fecha, LocalTime horaInicio, LocalTime horaFin);
+    List<MesaDto> buscarMesasDisponibles(LocalDate fecha, LocalTime hora);
 }

--- a/src/main/java/agile/aresback/service/DisponibilidadService.java
+++ b/src/main/java/agile/aresback/service/DisponibilidadService.java
@@ -1,0 +1,10 @@
+package agile.aresback.service;
+
+import agile.aresback.dto.DisponibilidadDto;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public interface DisponibilidadService {
+    List<DisponibilidadDto> obtenerMesasDisponibles(LocalDate fecha, LocalTime horaInicio, LocalTime horaFin);
+}

--- a/src/main/java/agile/aresback/service/Impl/DisponibilidadServiceImpl.java
+++ b/src/main/java/agile/aresback/service/Impl/DisponibilidadServiceImpl.java
@@ -33,7 +33,7 @@ public class DisponibilidadServiceImpl implements DisponibilidadService {
                 .map(mesa -> {
                     boolean ocupada = reservas.stream().anyMatch(r ->
                             r.getMesa().getId().equals(mesa.getId()) &&
-                                    r.getFechaReservada().toLocalDate().equals(fecha) &&
+                                    r.getFechaReservada().equals(fecha) && // ✅ Corregido aquí
                                     hora.isBefore(r.getHoraFin()) &&
                                     horaFin.isAfter(r.getHoraInicio()) &&
                                     (

--- a/src/main/java/agile/aresback/service/Impl/DisponibilidadServiceImpl.java
+++ b/src/main/java/agile/aresback/service/Impl/DisponibilidadServiceImpl.java
@@ -1,59 +1,55 @@
 package agile.aresback.service.Impl;
 
-import agile.aresback.dto.DisponibilidadDto;
-import agile.aresback.model.entity.Mesa;
+import agile.aresback.dto.MesaDto;
 import agile.aresback.model.entity.Reservation;
 import agile.aresback.model.enums.StateReservation;
+import agile.aresback.model.enums.StateTable;
 import agile.aresback.repository.MesaRepository;
 import agile.aresback.repository.ReservationRepository;
 import agile.aresback.service.DisponibilidadService;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
-@RequiredArgsConstructor
 public class DisponibilidadServiceImpl implements DisponibilidadService {
 
-    private final MesaRepository mesaRepository;
-    private final ReservationRepository reservationRepository;
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private MesaRepository mesaRepository;
 
     @Override
-    public List<DisponibilidadDto> obtenerMesasDisponibles(LocalDate fecha, LocalTime horaInicio, LocalTime horaFin) {
-        List<Mesa> todasLasMesas = mesaRepository.findAll();
-        List<Reservation> reservas = reservationRepository.findByFechaHora(fecha.atStartOfDay(), horaInicio, horaFin);
+    public List<MesaDto> buscarMesasDisponibles(LocalDate fecha, LocalTime hora) {
+        LocalTime horaFin = hora.plusHours(2);
 
-        return todasLasMesas.stream().map(mesa -> {
-            Optional<Reservation> reserva = reservas.stream()
-                    .filter(r -> r.getMesa().getId().equals(mesa.getId()))
-                    .findFirst();
+        List<Reservation> reservas = reservationRepository.findAll();
 
-            String estado;
-            if (reserva.isPresent()) {
-                StateReservation estadoReserva = reserva.get().getStateReservation();
-                switch (estadoReserva) {
-                    case EN_PROGRESO -> estado = "EN_PROGRESO";
-                    case OCUPADA -> estado = "OCUPADA";
-                    case EN_ESPERA -> estado = "EN_ESPERA";
-                    case ASISTIO -> estado = "ASISTIO";
-                    case NO_ASISTIO -> estado = "NO_ASISTIO";
-                    default -> estado = "RESERVADA";
-                }
-            } else {
-                estado = "DISPONIBLE";
-            }
+        return mesaRepository.findAll().stream()
+                .map(mesa -> {
+                    boolean ocupada = reservas.stream().anyMatch(r ->
+                            r.getMesa().getId().equals(mesa.getId()) &&
+                                    r.getFechaReservada().toLocalDate().equals(fecha) &&
+                                    hora.isBefore(r.getHoraFin()) &&
+                                    horaFin.isAfter(r.getHoraInicio()) &&
+                                    (
+                                            r.getStateReservation() == StateReservation.EN_ESPERA ||
+                                                    r.getStateReservation() == StateReservation.EN_PROGRESO ||
+                                                    r.getStateReservation() == StateReservation.OCUPADA
+                                    )
+                    );
 
-            return new DisponibilidadDto(
-                    mesa.getNumeroMesa(),
-                    mesa.getCapacidad(),
-                    mesa.getZone().getName(),
-                    estado
-            );
-        }).collect(Collectors.toList());
+                    return new MesaDto(
+                            mesa.getNumeroMesa(),
+                            mesa.getCapacidad(),
+                            ocupada ? StateTable.RESERVADO : StateTable.DISPONIBLE,
+                            mesa.getZone().getName()
+                    );
+                })
+                .toList();
     }
 }

--- a/src/main/java/agile/aresback/service/Impl/DisponibilidadServiceImpl.java
+++ b/src/main/java/agile/aresback/service/Impl/DisponibilidadServiceImpl.java
@@ -44,9 +44,10 @@ public class DisponibilidadServiceImpl implements DisponibilidadService {
                     );
 
                     return new MesaDto(
-                            mesa.getNumeroMesa(),
+                            mesa.getId(),
                             mesa.getCapacidad(),
-                            ocupada ? StateTable.RESERVADO : StateTable.DISPONIBLE,
+                            (ocupada ? StateTable.RESERVADO : StateTable.DISPONIBLE).name(),
+                            mesa.getNumeroMesa(),
                             mesa.getZone().getName()
                     );
                 })

--- a/src/main/java/agile/aresback/service/Impl/DisponibilidadServiceImpl.java
+++ b/src/main/java/agile/aresback/service/Impl/DisponibilidadServiceImpl.java
@@ -1,0 +1,59 @@
+package agile.aresback.service.Impl;
+
+import agile.aresback.dto.DisponibilidadDto;
+import agile.aresback.model.entity.Mesa;
+import agile.aresback.model.entity.Reservation;
+import agile.aresback.model.enums.StateReservation;
+import agile.aresback.repository.MesaRepository;
+import agile.aresback.repository.ReservationRepository;
+import agile.aresback.service.DisponibilidadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DisponibilidadServiceImpl implements DisponibilidadService {
+
+    private final MesaRepository mesaRepository;
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public List<DisponibilidadDto> obtenerMesasDisponibles(LocalDate fecha, LocalTime horaInicio, LocalTime horaFin) {
+        List<Mesa> todasLasMesas = mesaRepository.findAll();
+        List<Reservation> reservas = reservationRepository.findByFechaHora(fecha.atStartOfDay(), horaInicio, horaFin);
+
+        return todasLasMesas.stream().map(mesa -> {
+            Optional<Reservation> reserva = reservas.stream()
+                    .filter(r -> r.getMesa().getId().equals(mesa.getId()))
+                    .findFirst();
+
+            String estado;
+            if (reserva.isPresent()) {
+                StateReservation estadoReserva = reserva.get().getStateReservation();
+                switch (estadoReserva) {
+                    case EN_PROGRESO -> estado = "EN_PROGRESO";
+                    case OCUPADA -> estado = "OCUPADA";
+                    case EN_ESPERA -> estado = "EN_ESPERA";
+                    case ASISTIO -> estado = "ASISTIO";
+                    case NO_ASISTIO -> estado = "NO_ASISTIO";
+                    default -> estado = "RESERVADA";
+                }
+            } else {
+                estado = "DISPONIBLE";
+            }
+
+            return new DisponibilidadDto(
+                    mesa.getNumeroMesa(),
+                    mesa.getCapacidad(),
+                    mesa.getZone().getName(),
+                    estado
+            );
+        }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/agile/aresback/service/Impl/ReservationServiceImpl.java
+++ b/src/main/java/agile/aresback/service/Impl/ReservationServiceImpl.java
@@ -1,8 +1,6 @@
 package agile.aresback.service.Impl;
 
-import agile.aresback.model.entity.Mesa;
 import agile.aresback.model.entity.Reservation;
-import agile.aresback.repository.MesaRepository;
 import agile.aresback.repository.ReservationRepository;
 import agile.aresback.service.ReservationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ReservationServiceImpl implements ReservationService {
@@ -17,37 +16,28 @@ public class ReservationServiceImpl implements ReservationService {
     @Autowired
     private ReservationRepository reservationRepository;
 
-    @Autowired
-    private MesaRepository mesaRepository;
-
-    /*@Override
-    public List<Reservation> getReservationsForMesa(Mesa mesa) {
-        return reservationRepository.findByMesa(mesa); // Obtener las reservas de una mesa
-    }*/
-
     @Override
     public Reservation createReservation(Reservation reservation) {
-        return reservationRepository.save(reservation); // Crear una nueva reserva
+        return reservationRepository.save(reservation);
     }
 
     @Override
     public List<Reservation> getReservationsByTimeRange(LocalDateTime startTime, LocalDateTime endTime) {
-        return reservationRepository.findByFechaReservadaBetween(startTime, endTime); // Obtener reservas dentro de un
-                                                                                      // rango de tiempo
+        return reservationRepository.findByFechaReservadaBetween(startTime, endTime);
     }
 
     @Override
     public List<Reservation> findAll() {
-        return reservationRepository.findAll(); // Obtener todas las reservas
+        return reservationRepository.findAll();
     }
 
     @Override
-    public java.util.Optional<Reservation> findById(Integer id) {
-        return reservationRepository.findById(id); // Obtener una reserva por ID
+    public Optional<Reservation> findById(Integer id) {
+        return reservationRepository.findById(id);
     }
 
     @Override
     public void deleteById(Integer id) {
-        reservationRepository.deleteById(id); // Eliminar una reserva por ID
+        reservationRepository.deleteById(id);
     }
 }

--- a/src/main/java/agile/aresback/service/Impl/ReservationServiceImpl.java
+++ b/src/main/java/agile/aresback/service/Impl/ReservationServiceImpl.java
@@ -21,10 +21,10 @@ public class ReservationServiceImpl implements ReservationService {
     @Autowired
     private MesaRepository mesaRepository;
 
-    @Override
+    /*@Override
     public List<Reservation> getReservationsForMesa(Mesa mesa) {
         return reservationRepository.findByMesa(mesa); // Obtener las reservas de una mesa
-    }
+    }*/
 
     @Override
     public Reservation createReservation(Reservation reservation) {

--- a/src/main/java/agile/aresback/service/Impl/ReservationServiceImpl.java
+++ b/src/main/java/agile/aresback/service/Impl/ReservationServiceImpl.java
@@ -37,12 +37,12 @@ public class ReservationServiceImpl implements ReservationService {
 
     @Override
     public List<Reservation> getReservationsForMesa(Mesa mesa) {
-        return reservationRepository.findByMesa(mesa);
+        return reservationRepository.findByMesa(mesa); // Asegúrate de que este método exista en tu repositorio
     }
 
     @Override
     public Reservation createReservation(Reservation reservation) {
-        return reservationRepository.save(reservation); // Crear una nueva reserva
+        return reservationRepository.save(reservation);
     }
 
     @Override
@@ -61,10 +61,10 @@ public class ReservationServiceImpl implements ReservationService {
         Mesa mesa = mesaService.findById(reservationDTO.getMesaId())
                 .orElseThrow(() -> new RuntimeException("Mesa no encontrada"));
 
-        LocalDateTime ahora = LocalDateTime.now();
+        LocalDate fechaActual = LocalDate.now(); // ✅ separa fecha
+        LocalTime horaActual = LocalTime.now();  // ✅ separa hora
         LocalTime horaFinCalculada = reservationDTO.getHoraInicio().plusHours(2);
 
-        // Validar conflictos antes de crear la reserva
         List<Reservation> conflictos = reservationRepository.findConflictingReservations(
                 mesa.getId(),
                 reservationDTO.getFechaReservada(),
@@ -76,10 +76,8 @@ public class ReservationServiceImpl implements ReservationService {
         }
 
         Reservation reservation = reservationMapper.toEntity(reservationDTO, client, mesa);
-        reservation.setFechaRegistro(ahora);
-        reservation.setHoraFin(horaFinCalculada);
-
-        // Forzar estado a EN_ESPERA
+        reservation.setFechaRegistro(fechaActual);  // LocalDate
+        reservation.setHoraFin(horaFinCalculada);   // LocalTime
         reservation.setStateReservation(StateReservation.EN_ESPERA);
 
         return createReservation(reservation);
@@ -98,12 +96,10 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     public Optional<Reservation> findById(Integer id) {
         return reservationRepository.findById(id);
-    public java.util.Optional<Reservation> findById(Integer id) {
-        return reservationRepository.findById(id);
     }
 
     @Override
     public void deleteById(Integer id) {
-        reservationRepository.deleteById(id); // Eliminar una reserva por ID
+        reservationRepository.deleteById(id);
     }
 }

--- a/src/main/java/agile/aresback/service/ReservationService.java
+++ b/src/main/java/agile/aresback/service/ReservationService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface ReservationService {
 
-    List<Reservation> getReservationsForMesa(Mesa mesa); // Obtener reservas de una mesa
+    //List<Reservation> getReservationsForMesa(Mesa mesa); // Obtener reservas de una mesa
     Reservation createReservation(Reservation reservation); // Crear una nueva reserva
     List<Reservation> getReservationsByTimeRange(LocalDateTime startTime, LocalDateTime endTime); // Obtener reservas dentro de un rango de tiempo
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ server.servlet.context-path=/api/v1
 # Datos de conexi�n a MySQL
 spring.datasource.url=jdbc:mysql://localhost:3306/ares_bd?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=123456
+spring.datasource.password=adminadmin
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Configuraci�n JPA


### PR DESCRIPTION
Se implementó la lógica para mostrar mesas disponibles según la fecha y hora seleccionada por el cliente.
La funcionalidad incluye:
Validación de mesas ocupadas comparando reservas activas en un rango de 2 horas.
Diferenciación del estado de las mesas (DISPONIBLE o RESERVADO) según disponibilidad real.
Adaptación del backend para trabajar con LocalDate y LocalTime, cumpliendo con la nueva estructura del modelo.
Filtrado dinámico para evitar mostrar mesas con reservas en conflicto de hora o fecha.
![image](https://github.com/user-attachments/assets/4fdec57d-a230-4015-8db7-1703fb17d99b)
