### PR TITLE
feat: modificar asistencia

### DIFF
--- a/src/main/java/agile/aresback/api/ReservationController.java
+++ b/src/main/java/agile/aresback/api/ReservationController.java
@@ -111,4 +111,13 @@ public class ReservationController {
         reservationService.deleteById(id);
         return ResponseEntity.noContent().build();
     }
+    @PutMapping("/{id}/confirm-attendance")
+    public ResponseEntity<ReservationDTO> confirmAttendance(@PathVariable Integer id) {
+        // Llamar al servicio para confirmar la asistencia
+        Reservation updatedReservation = reservationService.confirmAttendance(id);
+
+        // Retornar la reserva actualizada como un DTO
+        return ResponseEntity.ok(reservationMapper.toDTO(updatedReservation));
+    }
+
 }

--- a/src/main/java/agile/aresback/service/Impl/ReservationServiceImpl.java
+++ b/src/main/java/agile/aresback/service/Impl/ReservationServiceImpl.java
@@ -18,6 +18,7 @@ import agile.aresback.service.ReservationService;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import agile.aresback.exception.ResourceNotFoundException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -143,8 +144,27 @@ public class ReservationServiceImpl implements ReservationService {
         }
     }
 
+    @Override
+    @Transactional
+    public Reservation confirmAttendance(Integer id) {
+        // Buscar la reserva por ID
+        Optional<Reservation> optionalReservation = reservationRepository.findById(id);
+        if (!optionalReservation.isPresent()) {
+            throw new ResourceNotFoundException("Reservation not found");
+        }
 
+        Reservation reservation = optionalReservation.get();
 
+        // Verificar si el estado actual es "EN_ESPERA"
+        if (reservation.getStateReservationClient() == StateReservationClient.EN_ESPERA) {
+            // Cambiar el estado a "ASISTIO"
+            reservation.setStateReservationClient(StateReservationClient.ASISTIO);
 
+            // Guardar la reserva actualizada
+            return reservationRepository.save(reservation);
+        }
 
+        // Si la reserva no está en "EN_ESPERA", lanzar una excepción
+        throw new IllegalStateException("The reservation has already been confirmed or is in a different state");
+    }
 }

--- a/src/main/java/agile/aresback/service/ReservationService.java
+++ b/src/main/java/agile/aresback/service/ReservationService.java
@@ -29,4 +29,5 @@ public interface ReservationService {
 
     void deleteById(Integer id);
 
+    Reservation confirmAttendance(Integer id);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,7 @@ server.port=${PORT:8080}
 # Datos de conexi�n a MySQL
 spring.datasource.url=jdbc:mysql://localhost:3306/ares_bd?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=123456
+spring.datasource.password=adminadmin
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Configuraci�n JPA


### PR DESCRIPTION
Se implementó la funcionalidad de confirmación de asistencia en el módulo de reservas del administrador.

- Se añadió un botón “Confirmar” al lado de las reservas con estado EN_ESPERA.
- Al hacer clic, el estado cambia a ASISTIÓ y se actualiza visualmente.
- Además, se muestra un mensaje de confirmación.
![image](https://github.com/user-attachments/assets/4395d77e-a765-457e-a73a-d36ad77c66bb)
![image](https://github.com/user-attachments/assets/2dc26dc4-99e7-4cdc-80a7-6d633e8e8339)
![image](https://github.com/user-attachments/assets/eaed5036-910f-4366-9756-37879d8df9f7)

